### PR TITLE
Fix HELO greeting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 sed -i "s/##DB_PASS##/${DB_ENV_MYSQL_PASSWORD}/" /etc/postfix/virtual-mailbox-domains.cf
 sed -i "s/##DB_PASS##/${DB_ENV_MYSQL_PASSWORD}/" /etc/postfix/virtual-mailbox-maps.cf

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,7 @@
 sed -i "s/##DB_PASS##/${DB_ENV_MYSQL_PASSWORD}/" /etc/postfix/virtual-mailbox-domains.cf
 sed -i "s/##DB_PASS##/${DB_ENV_MYSQL_PASSWORD}/" /etc/postfix/virtual-mailbox-maps.cf
 sed -i "s/##DB_PASS##/${DB_ENV_MYSQL_PASSWORD}/" /etc/postfix/virtual-alias-maps.cf
-sed -i "s/##HOSTNAME##/${HOSTNAME}/" /etc/postfix/virtual-alias-maps.cf
-sed -i "s/##HOSTNAME##/${HOSTNAME}/" /etc/postfix/main.cf
+sed -i "s/##HOSTNAME##/$(hostname --fqdn)/" /etc/postfix/main.cf
 
 /opt/mysql-check.sh
 


### PR DESCRIPTION
We have experienced mail not being delivered with following error:

    lost connection with ... while performing the HELO handshake

My HELO greeting showed:

    220 mail ESMTP Hi, I'm hosted by an IndieHoster (Debian/Postfix; see https://indiehosters.net/)

Most likely the problem is that not the FQDN is returned. This is because the HOSTNAME environment variable is set to `mail` instead of `mail.example.com` (at least with my setup).